### PR TITLE
make detect_ip configurable

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,6 @@
 {
     "server": "http://10.0.0.1",
+    "detect_ip": false,
     "strict_bind": false,
     "double_stack": false,
     "retry_delay": 300,

--- a/src/file.rs
+++ b/src/file.rs
@@ -6,6 +6,7 @@ use std::{collections::LinkedList, error::Error, fs::File, io::BufReader, path::
 #[serde(default)]
 pub struct Config {
     pub server: Option<String>,
+    pub detect_ip: bool,
     pub strict_bind: bool,
     pub double_stack: bool,
     pub n: Option<i32>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ fn config_login(matches: Matches) {
             for user in config_i {
                 println!("login user: {:#?}", user);
                 let mut client = SrunClient::new_from_user(&server, user)
+                    .set_detect_ip(config.detect_ip)
                     .set_strict_bind(config.strict_bind)
                     .set_double_stack(config.double_stack);
                 if let Some(n) = config.n {


### PR DESCRIPTION
'detect_ip' can be set in command opts by '-d', config file mode need it too
If this program run under NAT, interface ip doesn't match 'client_ip', srun server disallowed unmatched 'client_ip' and 'online_ip'